### PR TITLE
Fix clang linker error

### DIFF
--- a/Example App/Radial Menu.xcodeproj/project.pbxproj
+++ b/Example App/Radial Menu.xcodeproj/project.pbxproj
@@ -654,7 +654,6 @@
 		C909C7E819480AFC00080438 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Example App.app/Example App";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -674,7 +673,6 @@
 		C909C7E919480AFC00080438 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/Example App.app/Example App";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",


### PR DESCRIPTION
Fixes #3 — `BUNDLE_LOADER` is referring to a file that doesn't exist.
